### PR TITLE
Fixed example to fetch master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```yaml
   - name: Deploy
-    uses: deployer/deploy@master
+    uses: deployphp/action@master
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}
@@ -37,7 +37,7 @@ deploy:
     with:
       php-version: 7.4
   - name: Deploy
-    uses: deployer/deploy@master
+    uses: deployphp/action@master
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```yaml
   - name: Deploy
-    uses: deployer/deploy@v1
+    uses: deployer/deploy@master
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}
@@ -37,7 +37,7 @@ deploy:
     with:
       php-version: 7.4
   - name: Deploy
-    uses: deployer/deploy@v1
+    uses: deployer/deploy@master
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}


### PR DESCRIPTION
The example in README.md was using the not-valid v1 release. I changed it to master which should always work. 

It is also using `deployer/deploy`, where it should be `deployphp/action` with current repo name. I would actually change the repository name to be `deployer-action` so that the correct package name would be `deployphp/deployer-action@master`