### PR TITLE
Check if we need to create SSH directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ void function main() {
 
 function ssh() {
   let ssh = `${process.env['HOME']}/.ssh`
-  fs.mkdirSync(ssh)
+
+  if (!fs.existsSync(ssh)) {
+    fs.mkdirSync(ssh)
+  }
 
   let authSock = '/tmp/ssh-auth.sock'
   execa.sync('ssh-agent', ['-a', authSock])


### PR DESCRIPTION
This action was failing when running on `ubuntu-latest` with the error: `EEXIST: file already exists, mkdir '/home/runner/.ssh'`

Simply checking if the SSH directory exists before creating it resolves the issue.