### PR TITLE
Add ssh-config input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}
+      ssh-config: ${{ secrets.SSH_CONFIG }}
       dep: deploy prod -v
 ```
 
 ## Inputs
 
 - `private-key` - Required. A private key to accessing servers.
-- `known-hosts` - Optional. Host fingerprints. If omitted `StrictHostKeyChecking=no` will be used.
+- `known-hosts` - Optional. Host fingerprints. If omitted `StrictHostKeyChecking=no` will be used unless `ssh-config` is provided.
+- `ssh-config` - Optional. SSH configuration.
 - `dep` - Required. Arguments to pass to Deployer command.
 
 ## Deployer version
@@ -41,5 +43,6 @@ deploy:
     with:
       private-key: ${{ secrets.PRIVATE_KEY }}
       known-hosts: ${{ secrets.KNOWN_HOSTS }}
+      ssh-config: ${{ secrets.SSH_CONFIG }}
       dep: deploy prod -v
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'Known hosts'
     required: false
     default: ''
+  ssh-config:
+    description: 'SSH configuration'
+    required: false
+    default: ''
   dep:
     description: 'Deployer command'
     required: false

--- a/index.js
+++ b/index.js
@@ -26,12 +26,17 @@ function ssh() {
   let privateKey = core.getInput('private-key').replace('/\r/g', '').trim() + '\n'
   execa.sync('ssh-add', ['-'], {input: privateKey})
 
-  let knownHosts = core.getInput('known-hosts')
-  if (knownHosts === '') {
-    fs.appendFileSync(`${ssh}/config`, `StrictHostKeyChecking no`)
-  } else {
+  const knownHosts = core.getInput('known-hosts')
+  if (knownHosts !== '') {
     fs.appendFileSync(`${ssh}/known_hosts`, knownHosts)
     fs.chmodSync(`${ssh}/known_hosts`, '644')
+  } else {
+    fs.appendFileSync(`${ssh}/config`, `StrictHostKeyChecking no`)
+  }
+
+  const sshConfig = core.getInput('ssh-config')
+  if (sshConfig !== '') {
+    fs.writeFile(`${ssh}/config`, sshConfig)
   }
 }
 


### PR DESCRIPTION
Allows to set `~/.sss/config` from the `ssh-config` input.

Closes #10

Note: this is my first contribution on a GitHub action. I have not found a way to test this properly for now.