### PR TITLE
fixing relative path and permission

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,16 @@ function ssh() {
   const knownHosts = core.getInput('known-hosts')
   if (knownHosts !== '') {
     fs.appendFileSync(`${ssh}/known_hosts`, knownHosts)
-    fs.chmodSync(`${ssh}/known_hosts`, '644')
+    fs.chmodSync(`${ssh}/known_hosts`, '600')
   } else {
     fs.appendFileSync(`${ssh}/config`, `StrictHostKeyChecking no`)
+    fs.chmodSync(`${ssh}/config`, '600')
   }
 
   const sshConfig = core.getInput('ssh-config')
   if (sshConfig !== '') {
     fs.writeFile(`${ssh}/config`, sshConfig)
+    fs.chmodSync(`${ssh}/config`, '600')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function dep() {
   if (!dep) {
     execa.commandSync('curl -LO https://deployer.org/deployer.phar')
     execa.commandSync('sudo chmod +x deployer.phar')
-    dep = 'deployer.phar'
+    dep = './deployer.phar'
   }
 
   const subprocess = execa(dep, split(core.getInput('dep')))


### PR DESCRIPTION
First, you have to use relative path when execute command or you will have a error
Error: Command failed with ENOENT: deployer.phar deploy -vvv
spawn deployer.phar ENOENT

Second, next files .ssh/known_hosts and .ssh/config must have permissions 600, if it is not true you will have a error from ssh client.