### PR TITLE
Remove --ansi flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ async function dep() {
 
   let cmd = core.getInput('dep')
 
-  let p = execa.command(`php ${dep} --no-interaction --ansi -v ${cmd}`)
+  let p = execa.command(`php ${dep} --no-interaction -v ${cmd}`)
   p.stdout.pipe(process.stdout)
   p.stderr.pipe(process.stderr)
 


### PR DESCRIPTION
This PR removes the --ansi flag from the deploy command.

With ansi enabled, errors in actions when using dark mode on GitHub are garish and blinding. Passing `--no-ansi` to the dep option doesn't work, presumably because the `--ansi` flag comes before it.

By removing it, it can be left to the developer to explicitly enable or disable it within the `dep` option, e.g:

```yaml
with:
  dep: deploy --no-ansi
```

Or

```yaml
with:
  dep: deploy --ansi
```