### PR TITLE
Add ansi and verbosity input options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@
       # You can specify path to your local Deployer binary in the repo.
       # Optional.
       deployer-binary: "bin/dep"
+
+      # You can choose to disable ANSI output.
+      # Optional. Defaults to true.
+      ansi: false
+
+      # You can specify the output verbosity level.
+      # Optional. Defaults to -v.
+      verbosity: -vvv
 ```
 
 ## Example

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,16 @@ inputs:
     default: ''
     description: Path to local Deployer binary.
 
+  ansi:
+    required: false
+    default: 'true'
+    description: Whether to enable ANSI output.
+
+  verbosity:
+    required: false
+    default: '-v'
+    description: Verbosity level Can be -v, -vv or -vvv.
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -81,8 +81,10 @@ async function dep() {
   }
 
   let cmd = core.getInput('dep')
+  let ansi = core.getBooleanInput('ansi') ? '--ansi' : '--no-ansi';
+  let verbosity = core.getInput('verbosity');
 
-  let p = execa.command(`php ${dep} --no-interaction --ansi -v ${cmd}`)
+  let p = execa.command(`php ${dep} --no-interaction ${ansi} ${verbosity} ${cmd}`)
   p.stdout.pipe(process.stdout)
   p.stderr.pipe(process.stderr)
 


### PR DESCRIPTION
This PR supersedes #41

It adds an `ansi` boolean option (defaults to true) which passes either `--ansi` or `--no-ansi` depending on whether it's true or false respectively.

This means ansi will remain enabled by default with no changes required by anyone, but developers can choose to disable it if they want.

The PR also adds a `verbosity` option so developers can change the current `-v` to `-vv` or `-vvv` if desired.