### PR TITLE
Set `private-key` as non required

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   - name: Deploy
     uses: deployphp/action@v1
     with:
-      private-key: ${{ secrets.PRIVATE_KEY }}
       dep: deploy
+      private-key: ${{ secrets.PRIVATE_KEY }}
 ```
 
 ## Inputs
@@ -14,15 +14,15 @@
   - name: Deploy
     uses: deployphp/action@v1
     with:
-      # Private key for connecting to remote hosts. To generate private key:
-      # `ssh-keygen -o -t rsa -C 'action@deployer.org'`.
-      # Required.
-      private-key: ${{ secrets.PRIVATE_KEY }}
-
       # The deployer task to run. For example:
       # `deploy all`.
       # Required.
       dep: deploy
+
+      # Private key for connecting to remote hosts. To generate private key:
+      # `ssh-keygen -o -t rsa -C 'action@deployer.org'`.
+      # Optional.
+      private-key: ${{ secrets.PRIVATE_KEY }}
 
       # Content of `~/.ssh/known_hosts` file. The public SSH keys for a
       # host may be obtained using the utility `ssh-keyscan`. 
@@ -87,6 +87,6 @@ jobs:
       - name: Deploy
         uses: deployphp/action@v1
         with:
-          private-key: ${{ secrets.PRIVATE_KEY }}
           dep: deploy
+          private-key: ${{ secrets.PRIVATE_KEY }}
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -4,13 +4,14 @@ description: 'Deploy with Deployer'
 
 inputs:
 
-  private-key:
-    required: true
-    description: The private key for connecting to remote hosts.
-
   dep:
     required: true
     description: The command.
+
+  private-key:
+    required: false
+    default: ''
+    description: The private key for connecting to remote hosts.
 
   known-hosts:
     required: false

--- a/index.js
+++ b/index.js
@@ -22,8 +22,11 @@ async function ssh() {
   execa.sync('ssh-agent', ['-a', authSock])
   core.exportVariable('SSH_AUTH_SOCK', authSock)
 
-  let privateKey = core.getInput('private-key').replace('/\r/g', '').trim() + '\n'
-  execa.sync('ssh-add', ['-'], {input: privateKey})
+  let privateKey = core.getInput('private-key')
+  if (privateKey !== '') {
+    privateKey = privateKey.replace('/\r/g', '').trim() + '\n'
+    execa.sync('ssh-add', ['-'], {input: privateKey})
+  }
 
   const knownHosts = core.getInput('known-hosts')
   if (knownHosts !== '') {


### PR DESCRIPTION
Fix #47 by setting `private-key` input as not required.

One question I have is do I skip totally the ssh part if no `private-key` is provided? Here I only skip the `ssh-add` part.