### PR TITLE
Fix handling of config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@
       sub-directory: "..."
       
       # Config options for the Deployer. Same as the `-o` flag in the CLI.
+      # Must be a JSON object.
       # Optional.
-      options:
-        keep_releases: 7
+      options: |
+        {
+          "keep_releases": 7
+        }
 
       # Private key for connecting to remote hosts. To generate private key:
       # `ssh-keygen -o -t rsa -C 'action@deployer.org'`.

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ async function dep() {
   let verbosity = core.getInput('verbosity')
   let options = []
   try {
-    for (let [key, value] in Object.entries(JSON.parse(core.getInput('options')))) {
+    for (let [key, value] of Object.entries(JSON.parse(core.getInput('options')))) {
       options.push('-o', `${key}=${value}`)
     }
   } catch (e) {


### PR DESCRIPTION
Currently, config options are passed as `-o 0=undefined -o 1=undefined` because of the `for .. in` loop.

I also updated the `README.md` to emphasize that a JSON object is expected.