### PR TITLE
handle errors in dep, correctly catch missing url in version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,8 +94,8 @@ async function dep() {
         break
       }
     }
-    if (url === null) {
-      console.error(`The version "${version}"" does not exist in the "https://deployer.org/manifest.json" file."`)
+    if (typeof url === 'undefined') {
+      throw new Error(`The version "${version}"" does not exist in the "https://deployer.org/manifest.json" file."`)
     } else {
       console.log(`Downloading "${url}".`)
       await $`curl -LO ${url}`
@@ -114,12 +114,12 @@ async function dep() {
       options.push('-o', `${key}=${value}`)
     }
   } catch (e) {
-    console.error('Invalid JSON in options')
+    throw new Error('Invalid JSON in options')
   }
 
   try {
     await $`php ${dep} ${cmd} --no-interaction ${ansi} ${verbosity} ${options}`
   } catch (err) {
-    core.setFailed(`Failed: dep ${cmd}`)
+    throw new Error(`Failed: dep ${cmd}`)
   }
 }


### PR DESCRIPTION
replace console.error with throw to handle dep error failures in main try/catch to mark job as failed in one place

fixes: https://github.com/deployphp/action/issues/63