### PR TITLE
feat: add support for specifying a recipe file path

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,11 @@ inputs:
     default: ''
     description: Path to local Deployer binary.
 
+  recipe:
+    required: false
+    default: ''
+    description: Recipe file path.
+
   ansi:
     required: false
     default: 'true'

--- a/index.js
+++ b/index.js
@@ -106,6 +106,11 @@ async function dep() {
   }
 
   let cmd = core.getInput('dep').split(' ')
+  let recipe = core.getInput('recipe')
+  if (recipe !== '') {
+    recipe = `--file=${recipe}`
+  }
+
   let ansi = core.getBooleanInput('ansi') ? '--ansi' : '--no-ansi'
   let verbosity = core.getInput('verbosity')
   let options = []
@@ -118,7 +123,7 @@ async function dep() {
   }
 
   try {
-    await $`php ${dep} ${cmd} --no-interaction ${ansi} ${verbosity} ${options}`
+    await $`php ${dep} ${cmd} ${recipe} --no-interaction ${ansi} ${verbosity} ${options}`
   } catch (err) {
     core.setFailed(`Failed: dep ${cmd}`)
   }


### PR DESCRIPTION
See command usage description:

```sh
Deployer 7.3.1

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -f, --file=FILE       Recipe file path
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  blackjack    Play blackjack
  completion   Dump the shell completion script
  config       Get all configuration options for hosts
  help         Display help for a command
  init         Initialize deployer in your project
  list         List commands
  run          Run any arbitrary command on hosts
  self-update  Updates deployer.phar to the latest version
  ssh          Connect to host through ssh
  tree         Display the task-tree for a given task
```