### PR TITLE
Improve hanlding of ssh-agent process

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,11 @@ inputs:
     default: ''
     description: Content of `~/.ssh/known_hosts` file.
 
+  disable-strict-host-checking:
+    required: false
+    default: 'true'
+    description: Disable Strict Host Checking if no known_hosts are provided
+
   ssh-config:
     required: false
     default: ''
@@ -71,6 +76,7 @@ inputs:
 runs:
   using: 'node20'
   main: 'index.js'
+  post: 'cleanup.js'
 
 branding:
   color: blue

--- a/cleanup.js
+++ b/cleanup.js
@@ -14,7 +14,9 @@ async function cleanup() {
     return
   }
 
+  const sshAgentPid = core.getState('ssh-agent-pid')
+
   // Remove all keys from ssh-agent and kill process
   await $`ssh-add -D`
-  await $`kill \$SSH_AGENT_PID`
+  await $`kill ${sshAgentPid}`
 }

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,20 @@
+import core from '@actions/core'
+import { $ } from 'zx'
+
+void (async function main() {
+  try {
+    await cleanup()
+  } catch (err) {
+    core.setFailed(err.message)
+  }
+})()
+
+async function cleanup() {
+  if (core.getBooleanInput('skip-ssh-setup')) {
+    return
+  }
+
+  // Remove all keys from ssh-agent and kill process
+  await $`ssh-add -D`
+  await $`kill \$SSH_AGENT_PID`
+}

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ async function ssh() {
   }
 
   core.exportVariable('SSH_AUTH_SOCK', sshAgentSocket.trim())
-  core.exportVariable('SSH_AGENT_PID', sshAgentProcessId.trim())
+  core.exportVariable('SSH_AGENT_PID', )
+
+  core.saveState('ssh-agent-pid', sshAgentProcessId.trim())
 
   let privateKey = core.getInput('private-key')
   if (privateKey !== '') {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ async function ssh() {
     fs.mkdirSync(sshHomeDir)
   }
 
+  // Unfortunately running the output into bash or eval-ing it does
+  // not persist the exported environment variables, so instead we
+  // parse out the variables via regex, not ideal but works a treat.
   const sshAgentOutput = await $`ssh-agent`
 
   const sshAgentSocket = sshAgentOutput
@@ -38,7 +41,7 @@ async function ssh() {
   }
 
   core.exportVariable('SSH_AUTH_SOCK', sshAgentSocket.trim())
-  core.exportVariable('SSH_AGENT_PID', )
+  core.exportVariable('SSH_AGENT_PID', sshAgentProcessId.trim())
 
   core.saveState('ssh-agent-pid', sshAgentProcessId.trim())
 

--- a/index.js
+++ b/index.js
@@ -21,11 +21,17 @@ async function ssh() {
     fs.mkdirSync(sshHomeDir)
   }
 
-  await $`eval \`ssh-agent\``
+  const sshAgentOutput = await $`ssh-agent`
 
-  const sshAgentSocket = await $`echo \$SSH_AUTH_SOCKET`
+  const sshAgentSocket = sshAgentOutput
+    .stdout
+    .match(/SSH_AUTH_SOCK=(?<path>.*); export SSH_AUTH_SOCK;/)
+    ?.groups['path'] ?? null;
 
-  const sshAgentProcessId = await $`echo \$SSH_AGENT_PID`
+  const sshAgentProcessId = sshAgentOutput
+    .stdout
+    .match(/SSH_AGENT_PID=(?<pid>\d+); export SSH_AGENT_PID;/)
+    ?.groups['pid'] ?? null;
 
   if (!sshAgentSocket || !sshAgentProcessId) {
     throw new Error('Failed to start ssh-agent')


### PR DESCRIPTION
Currently I have the following added to all of my workflow files using the deployerphp action for our self hosted runners:

```
      - name: Clean Up SSH Agent
        if: always()
        run: |
          killall ssh-agent
          rm ~/.ssh/config
```

This works fine, however recently we had started having multiple runner instances on single servers and conflicts began to arise with my solution.

So I've decided to take a crack at implement a way of handling the `ssh-agent` process a little more nicely and have ended up with this.

There is probably a slightly better way of doing this via a proper setting, however I was aiming for backwards compatibility where possible.

What this PR does:

1. Spawns the SSH agent without specify a socket path, ensuring a unique socket path for each runner.
2. Adds a new option to toggle if the action should disable strict host checking if no known hosts are provided.
3. Adds a cleanup task that ensures all SSH keys are removed from the SSH Agent.
4. Ensures the SSH is shutdown on the runner server.


Why make these changes:

1. Improves supports for self hosted runners while also adding a bit of extra security for those using GitHub hosted runners.
2. Allows for the action to still handle the SSH related tasks for the end user without actually touching anything SSH related if necessary.
3. Probably doing things "the right way", so to speak, in that we're cleaning up after ourselves as part of the action.
