### PR TITLE
Fix verbosity parsing from options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36632,6 +36632,23 @@ var { VERSION, YAML, argv, dotenv, echo, expBackoff, fetch, fs, glob, globby, mi
 //#endregion
 //#region src/index.ts
 $.verbose = true;
+function parseOptions(input) {
+	if (input.trim() === "") return {};
+	try {
+		return JSON.parse(input);
+	} catch {
+		const options = {};
+		for (const line of input.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed === "" || trimmed.startsWith("#")) continue;
+			const match = trimmed.match(/^([^:#]+):\s*(.*)$/);
+			if (match === null) throw new Error("Invalid options format");
+			const [, key, value] = match;
+			options[key.trim()] = value.trim().replace(/^['"]|['"]$/g, "");
+		}
+		return options;
+	}
+}
 (async function main() {
 	try {
 		await ssh();
@@ -36712,16 +36729,21 @@ async function dep() {
 	const recipeInput = getInput("recipe");
 	if (recipeInput !== "") recipeArgs.push(`--file=${recipeInput}`);
 	const ansi = getBooleanInput("ansi") ? "--ansi" : "--no-ansi";
-	const verbosityArgs = [];
-	const verbosityInput = getInput("verbosity");
-	if (verbosityInput !== "") verbosityArgs.push(verbosityInput);
 	const options = [];
+	let verbosityInput = getInput("verbosity");
 	try {
-		const optionsArg = getInput("options");
-		if (optionsArg !== "") for (const [key, value] of Object.entries(JSON.parse(optionsArg))) options.push("-o", `${key}=${value}`);
+		const parsedOptions = parseOptions(getInput("options"));
+		if (parsedOptions.verbosity !== void 0) {
+			verbosityInput = parsedOptions.verbosity;
+			delete parsedOptions.verbosity;
+		}
+		for (const [key, value] of Object.entries(parsedOptions)) options.push("-o", `${key}=${value}`);
 	} catch (e) {
-		console.error("Invalid JSON in options");
+		setFailed("Invalid options format. Use JSON or key: value lines.");
+		return;
 	}
+	const verbosityArgs = [];
+	if (verbosityInput !== "") verbosityArgs.push(verbosityInput);
 	let phpBin = "php";
 	const phpBinArg = getInput("php-binary");
 	if (phpBinArg !== "") phpBin = phpBinArg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,33 @@ interface DeployerManifestEntry {
   url: string
 }
 
+type ParsedOptions = Record<string, string>
+
+function parseOptions(input: string): ParsedOptions {
+  if (input.trim() === '') {
+    return {}
+  }
+
+  try {
+    return JSON.parse(input) as ParsedOptions
+  } catch {
+    const options: ParsedOptions = {}
+    for (const line of input.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed === '' || trimmed.startsWith('#')) {
+        continue
+      }
+      const match = trimmed.match(/^([^:#]+):\s*(.*)$/)
+      if (match === null) {
+        throw new Error('Invalid options format')
+      }
+      const [, key, value] = match
+      options[key.trim()] = value.trim().replace(/^['"]|['"]$/g, '')
+    }
+    return options
+  }
+}
+
 void (async function main(): Promise<void> {
   try {
     await ssh()
@@ -138,21 +165,26 @@ async function dep(): Promise<void> {
   }
 
   const ansi = core.getBooleanInput('ansi') ? '--ansi' : '--no-ansi'
-  const verbosityArgs: string[] = []
-  const verbosityInput = core.getInput('verbosity')
-  if (verbosityInput !== '') {
-    verbosityArgs.push(verbosityInput)
-  }
   const options: string[] = []
+  let verbosityInput = core.getInput('verbosity')
   try {
     const optionsArg = core.getInput('options')
-    if (optionsArg !== '') {
-      for (const [key, value] of Object.entries(JSON.parse(optionsArg))) {
-        options.push('-o', `${key}=${value}`)
-      }
+    const parsedOptions = parseOptions(optionsArg)
+    if (parsedOptions.verbosity !== undefined) {
+      verbosityInput = parsedOptions.verbosity
+      delete parsedOptions.verbosity
+    }
+    for (const [key, value] of Object.entries(parsedOptions)) {
+      options.push('-o', `${key}=${value}`)
     }
   } catch (e) {
-    console.error('Invalid JSON in options')
+    core.setFailed('Invalid options format. Use JSON or key: value lines.')
+    return
+  }
+
+  const verbosityArgs: string[] = []
+  if (verbosityInput !== '') {
+    verbosityArgs.push(verbosityInput)
   }
 
   let phpBin = 'php'


### PR DESCRIPTION
## Summary
- parse the `options` input as either JSON or simple `key: value` lines, matching the documented YAML-style examples
- treat a `verbosity` key in `options` as the action verbosity setting instead of silently ignoring it or passing it as a Deployer config option
- fail fast with a clear message when `options` cannot be parsed

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #66