### PR TITLE
Replace known hosts from input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36657,7 +36657,7 @@ async function ssh() {
 	}
 	const knownHosts = getInput("known-hosts");
 	if (knownHosts !== "") {
-		fs.appendFileSync(`${sshHomeDir}/known_hosts`, knownHosts);
+		fs.writeFileSync(`${sshHomeDir}/known_hosts`, knownHosts);
 		fs.chmodSync(`${sshHomeDir}/known_hosts`, "600");
 	} else {
 		fs.appendFileSync(`${sshHomeDir}/config`, `StrictHostKeyChecking no`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function ssh(): Promise<void> {
 
   const knownHosts = core.getInput('known-hosts')
   if (knownHosts !== '') {
-    fs.appendFileSync(`${sshHomeDir}/known_hosts`, knownHosts)
+    fs.writeFileSync(`${sshHomeDir}/known_hosts`, knownHosts)
     fs.chmodSync(`${sshHomeDir}/known_hosts`, '600')
   } else {
     fs.appendFileSync(`${sshHomeDir}/config`, `StrictHostKeyChecking no`)


### PR DESCRIPTION
## Summary
- replace the runner `known_hosts` file with the provided `known-hosts` input instead of appending to any existing entries
- keeps permissions at `0600`
- rebuilds the bundled action output

This makes the input behave as an explicit known-hosts override, so stale runner fingerprints do not remain ahead of the supplied values.

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #62