### PR TITLE
Download manifest without logging body

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36693,7 +36693,9 @@ async function dep() {
 		}
 		if (version === "" || version === void 0) throw new Error("Deployer binary not found. Please specify deployer-binary or deployer-version.");
 		version = version.replace(/^v/, "");
-		const manifest = JSON.parse((await $`curl -L https://deployer.org/manifest.json`).stdout);
+		const manifestPath = `${process.env["RUNNER_TEMP"] ?? "."}/deployer-manifest.json`;
+		await $`curl -fsSL -o ${manifestPath} https://deployer.org/manifest.json`;
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 		let url;
 		for (const asset of manifest) if (asset.version === version) {
 			url = asset.url;

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,10 @@ async function dep(): Promise<void> {
       )
     }
     version = version.replace(/^v/, '')
+    const manifestPath = `${process.env['RUNNER_TEMP'] ?? '.'}/deployer-manifest.json`
+    await $`curl -fsSL -o ${manifestPath} https://deployer.org/manifest.json`
     const manifest: DeployerManifestEntry[] = JSON.parse(
-      (await $`curl -L https://deployer.org/manifest.json`).stdout,
+      fs.readFileSync(manifestPath, 'utf8'),
     )
     let url: string | undefined
     for (const asset of manifest) {


### PR DESCRIPTION
## Summary
- downloads `manifest.json` to a temp file instead of reading curl stdout
- keeps the manifest body out of normal action logs while preserving curl error output with `-fsSL`
- parses the saved manifest file before selecting the requested Deployer version
- rebuilds the bundled action output

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #88