### PR TITLE
Use unique ssh-agent socket path

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36644,7 +36644,7 @@ async function ssh() {
 	if (getBooleanInput("skip-ssh-setup")) return;
 	const sshHomeDir = `${process.env["HOME"]}/.ssh`;
 	if (!fs.existsSync(sshHomeDir)) fs.mkdirSync(sshHomeDir);
-	const authSock = "/tmp/ssh-auth.sock";
+	const authSock = `${process.env["RUNNER_TEMP"] ?? "/tmp"}/ssh-auth-${process.pid}.sock`;
 	await $`ssh-agent -a ${authSock}`;
 	exportVariable("SSH_AUTH_SOCK", authSock);
 	let privateKey = getInput("private-key");

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ async function ssh(): Promise<void> {
     fs.mkdirSync(sshHomeDir)
   }
 
-  const authSock = '/tmp/ssh-auth.sock'
+  const authSock = `${process.env['RUNNER_TEMP'] ?? '/tmp'}/ssh-auth-${process.pid}.sock`
   await $`ssh-agent -a ${authSock}`
   core.exportVariable('SSH_AUTH_SOCK', authSock)
 


### PR DESCRIPTION
## Summary
- uses a per-run ssh-agent socket path under `RUNNER_TEMP` instead of the fixed `/tmp/ssh-auth.sock`
- includes the current process id in the socket filename to avoid collisions on self-hosted runners
- rebuilds the bundled action output

This prevents repeated or concurrent action runs on the same runner from failing with `unix_listener: cannot bind to path /tmp/ssh-auth.sock: Address already in use`.

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #22