### PR TITLE
Show deploy command error details

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36728,7 +36728,8 @@ async function dep() {
 	try {
 		await $`${phpBin} ${bin} ${cmd} ${recipeArgs} --no-interaction ${ansi} ${verbosityArgs} ${options}`;
 	} catch (err) {
-		setFailed(`Failed: dep ${cmd}`);
+		const message = err instanceof Error ? err.message : String(err);
+		setFailed(`Failed: dep ${cmd.join(" ")}\n${message}`);
 	}
 }
 //#endregion

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ async function dep(): Promise<void> {
   try {
     await $`${phpBin} ${bin} ${cmd} ${recipeArgs} --no-interaction ${ansi} ${verbosityArgs} ${options}`
   } catch (err) {
-    core.setFailed(`Failed: dep ${cmd}`)
+    const message = err instanceof Error ? err.message : String(err)
+    core.setFailed(`Failed: dep ${cmd.join(' ')}\n${message}`)
   }
 }


### PR DESCRIPTION
## Summary
- include the actual thrown error message when the Deployer command fails
- show the joined `dep` command instead of the raw array coercion
- rebuild the bundled action output

This makes failures like missing `deployer.phar` surface the underlying ENOENT/details instead of only `Failed: dep ...`.

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #4