### PR TITLE
Check Composer global bin for Deployer

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36674,11 +36674,19 @@ async function dep() {
 	const subDirectory = getInput("sub-directory").trim();
 	if (subDirectory !== "") cd(subDirectory);
 	if (bin === "") {
-		for (const c of [
+		const candidates = [
 			"vendor/bin/deployer.phar",
 			"vendor/bin/dep",
 			"deployer.phar"
-		]) if (fs.existsSync(c)) {
+		];
+		try {
+			const composerHome = (await $`composer -n config --global home`).stdout.trim();
+			if (composerHome !== "") {
+				candidates.push(`${composerHome}/vendor/bin/deployer.phar`);
+				candidates.push(`${composerHome}/vendor/bin/dep`);
+			}
+		} catch (_) {}
+		for (const c of candidates) if (fs.existsSync(c)) {
 			bin = c;
 			console.log(`Using "${c}".`);
 			break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,11 +71,23 @@ async function dep(): Promise<void> {
   }
 
   if (bin === '') {
-    for (const c of [
+    const candidates = [
       'vendor/bin/deployer.phar',
       'vendor/bin/dep',
       'deployer.phar',
-    ]) {
+    ]
+
+    try {
+      const composerHome = (await $`composer -n config --global home`).stdout.trim()
+      if (composerHome !== '') {
+        candidates.push(`${composerHome}/vendor/bin/deployer.phar`)
+        candidates.push(`${composerHome}/vendor/bin/dep`)
+      }
+    } catch (_) {
+      // Composer may not be installed or configured. Fall back to local checks.
+    }
+
+    for (const c of candidates) {
       if (fs.existsSync(c)) {
         bin = c
         console.log(`Using "${c}".`)


### PR DESCRIPTION
## Summary
- checks Composer's global home when auto-detecting an existing Deployer binary
- adds both global `vendor/bin/deployer.phar` and `vendor/bin/dep` as candidates
- falls back to the existing local checks if Composer is unavailable or not configured
- rebuilds the bundled action output

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #76