### PR TITLE
Add passphrase support for SSH private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@
     # Optional.
     private-key: ${{ secrets.PRIVATE_KEY }}
 
+    # Passphrase for encrypted private keys.
+    # Optional.
+    private-key-passphrase: ${{ secrets.PRIVATE_KEY_PASSPHRASE }}
+
     # Content of `~/.ssh/known_hosts` file. The public SSH keys for a
     # host may be obtained using the utility `ssh-keyscan`.
     # For example: `ssh-keyscan deployer.org`.

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,11 @@ inputs:
     default: ''
     description: The private key for connecting to remote hosts.
 
+  private-key-passphrase:
+    required: false
+    default: ''
+    description: Passphrase for the private key.
+
   known-hosts:
     required: false
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -16106,6 +16106,38 @@ function exportVariable(name, val) {
 	issueCommand("set-env", { name }, convertedVal);
 }
 /**
+* Registers a secret which will get masked from logs
+*
+* @param secret - Value of the secret to be masked
+* @remarks
+* This function instructs the Actions runner to mask the specified value in any
+* logs produced during the workflow run. Once registered, the secret value will
+* be replaced with asterisks (***) whenever it appears in console output, logs,
+* or error messages.
+*
+* This is useful for protecting sensitive information such as:
+* - API keys
+* - Access tokens
+* - Authentication credentials
+* - URL parameters containing signatures (SAS tokens)
+*
+* Note that masking only affects future logs; any previous appearances of the
+* secret in logs before calling this function will remain unmasked.
+*
+* @example
+* ```typescript
+* // Register an API token as a secret
+* const apiToken = "abc123xyz456";
+* setSecret(apiToken);
+*
+* // Now any logs containing this value will show *** instead
+* console.log(`Using token: ${apiToken}`); // Outputs: "Using token: ***"
+* ```
+*/
+function setSecret(secret) {
+	issueCommand("add-mask", {}, secret);
+}
+/**
 * Gets the value of an input.
 * Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
 * Returns an empty string if the value is not defined.
@@ -36650,10 +36682,30 @@ async function ssh() {
 	let privateKey = getInput("private-key");
 	if (privateKey !== "") {
 		privateKey = privateKey.replace(/\r/g, "").trim() + "\n";
-		const p = $`ssh-add -`;
-		p.stdin.write(privateKey);
-		p.stdin.end();
-		await p;
+		const passphrase = getInput("private-key-passphrase");
+		if (passphrase === "") {
+			const p = $`ssh-add -`;
+			p.stdin.write(privateKey);
+			p.stdin.end();
+			await p;
+		} else {
+			setSecret(passphrase);
+			const keyPath = `${process.env["RUNNER_TEMP"] ?? "/tmp"}/deployer-ssh-key`;
+			const askpassPath = `${process.env["RUNNER_TEMP"] ?? "/tmp"}/deployer-ssh-askpass.sh`;
+			fs.writeFileSync(keyPath, privateKey, { mode: 384 });
+			fs.writeFileSync(askpassPath, `#!/bin/sh\nprintf '%s\\n' \"$DEPLOYER_SSH_KEY_PASSPHRASE\"\n`, { mode: 448 });
+			try {
+				process.env["DEPLOYER_SSH_KEY_PASSPHRASE"] = passphrase;
+				process.env["SSH_ASKPASS"] = askpassPath;
+				process.env["SSH_ASKPASS_REQUIRE"] = "force";
+				process.env["DISPLAY"] = process.env["DISPLAY"] ?? ":0";
+				await $`ssh-add ${keyPath}`;
+			} finally {
+				delete process.env["DEPLOYER_SSH_KEY_PASSPHRASE"];
+				fs.rmSync(keyPath, { force: true });
+				fs.rmSync(askpassPath, { force: true });
+			}
+		}
 	}
 	const knownHosts = getInput("known-hosts");
 	if (knownHosts !== "") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,30 @@ async function ssh(): Promise<void> {
   let privateKey = core.getInput('private-key')
   if (privateKey !== '') {
     privateKey = privateKey.replace(/\r/g, '').trim() + '\n'
-    const p = $`ssh-add -`
-    p.stdin.write(privateKey)
-    p.stdin.end()
-    await p
+    const passphrase = core.getInput('private-key-passphrase')
+    if (passphrase === '') {
+      const p = $`ssh-add -`
+      p.stdin.write(privateKey)
+      p.stdin.end()
+      await p
+    } else {
+      core.setSecret(passphrase)
+      const keyPath = `${process.env['RUNNER_TEMP'] ?? '/tmp'}/deployer-ssh-key`
+      const askpassPath = `${process.env['RUNNER_TEMP'] ?? '/tmp'}/deployer-ssh-askpass.sh`
+      fs.writeFileSync(keyPath, privateKey, { mode: 0o600 })
+      fs.writeFileSync(askpassPath, `#!/bin/sh\nprintf '%s\\n' \"$DEPLOYER_SSH_KEY_PASSPHRASE\"\n`, { mode: 0o700 })
+      try {
+        process.env['DEPLOYER_SSH_KEY_PASSPHRASE'] = passphrase
+        process.env['SSH_ASKPASS'] = askpassPath
+        process.env['SSH_ASKPASS_REQUIRE'] = 'force'
+        process.env['DISPLAY'] = process.env['DISPLAY'] ?? ':0'
+        await $`ssh-add ${keyPath}`
+      } finally {
+        delete process.env['DEPLOYER_SSH_KEY_PASSPHRASE']
+        fs.rmSync(keyPath, { force: true })
+        fs.rmSync(askpassPath, { force: true })
+      }
+    }
   }
 
   const knownHosts = core.getInput('known-hosts')


### PR DESCRIPTION
Fixes #28

## Summary
- Adds a `private-key-passphrase` input for encrypted SSH private keys.
- Uses `SSH_ASKPASS` with a temporary askpass script so `ssh-add` can unlock passphrase-protected keys in non-interactive GitHub Actions runners.
- Documents the new input and rebuilds the bundled action.

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`