### PR TITLE
Reuse existing SSH agent between action steps

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36644,9 +36644,13 @@ async function ssh() {
 	if (getBooleanInput("skip-ssh-setup")) return;
 	const sshHomeDir = `${process.env["HOME"]}/.ssh`;
 	if (!fs.existsSync(sshHomeDir)) fs.mkdirSync(sshHomeDir);
-	const authSock = "/tmp/ssh-auth.sock";
-	await $`ssh-agent -a ${authSock}`;
-	exportVariable("SSH_AUTH_SOCK", authSock);
+	const existingAuthSock = process.env["SSH_AUTH_SOCK"];
+	if (existingAuthSock !== void 0 && existingAuthSock !== "" && fs.existsSync(existingAuthSock)) console.log(`Using existing SSH agent socket at ${existingAuthSock}.`);
+	else {
+		const authSock = "/tmp/ssh-auth.sock";
+		await $`ssh-agent -a ${authSock}`;
+		exportVariable("SSH_AUTH_SOCK", authSock);
+	}
 	let privateKey = getInput("private-key");
 	if (privateKey !== "") {
 		privateKey = privateKey.replace(/\r/g, "").trim() + "\n";

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,14 @@ async function ssh(): Promise<void> {
     fs.mkdirSync(sshHomeDir)
   }
 
-  const authSock = '/tmp/ssh-auth.sock'
-  await $`ssh-agent -a ${authSock}`
-  core.exportVariable('SSH_AUTH_SOCK', authSock)
+  const existingAuthSock = process.env['SSH_AUTH_SOCK']
+  if (existingAuthSock !== undefined && existingAuthSock !== '' && fs.existsSync(existingAuthSock)) {
+    console.log(`Using existing SSH agent socket at ${existingAuthSock}.`)
+  } else {
+    const authSock = '/tmp/ssh-auth.sock'
+    await $`ssh-agent -a ${authSock}`
+    core.exportVariable('SSH_AUTH_SOCK', authSock)
+  }
 
   let privateKey = core.getInput('private-key')
   if (privateKey !== '') {


### PR DESCRIPTION
Fixes #31

## Summary
- Reuses an existing `SSH_AUTH_SOCK` when a previous deployphp/action step already started an SSH agent in the same job.
- Avoids starting a second agent on the fixed `/tmp/ssh-auth.sock` path, which can fail when multiple deployphp/action steps run in one workflow.
- Keeps the existing private key loading behavior, so provided keys are still added to the active agent.

## Validation
- `npm run typecheck`
- `npm run build`
- `git diff --check`