### PR TITLE
Support key-value option lines

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36632,6 +36632,23 @@ var { VERSION, YAML, argv, dotenv, echo, expBackoff, fetch, fs, glob, globby, mi
 //#endregion
 //#region src/index.ts
 $.verbose = true;
+function parseOptions(input) {
+	if (input.trim() === "") return {};
+	try {
+		return JSON.parse(input);
+	} catch {
+		const options = {};
+		for (const line of input.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed === "" || trimmed.startsWith("#")) continue;
+			const match = trimmed.match(/^([^:#]+):\s*(.*)$/);
+			if (match === null) throw new Error("Invalid options format");
+			const [, key, value] = match;
+			options[key.trim()] = value.trim().replace(/^["']|["']$/g, "");
+		}
+		return options;
+	}
+}
 (async function main() {
 	try {
 		await ssh();
@@ -36718,9 +36735,10 @@ async function dep() {
 	const options = [];
 	try {
 		const optionsArg = getInput("options");
-		if (optionsArg !== "") for (const [key, value] of Object.entries(JSON.parse(optionsArg))) options.push("-o", `${key}=${value}`);
+		for (const [key, value] of Object.entries(parseOptions(optionsArg))) options.push("-o", `${key}=${value}`);
 	} catch (e) {
-		console.error("Invalid JSON in options");
+		setFailed("Invalid options format. Use JSON or key: value lines.");
+		return;
 	}
 	let phpBin = "php";
 	const phpBinArg = getInput("php-binary");

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,34 @@ interface DeployerManifestEntry {
   url: string
 }
 
+function parseOptions(input: string): Record<string, string> {
+  if (input.trim() === '') {
+    return {}
+  }
+
+  try {
+    return JSON.parse(input) as Record<string, string>
+  } catch {
+    const options: Record<string, string> = {}
+    for (const line of input.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed === '' || trimmed.startsWith('#')) {
+        continue
+      }
+
+      const match = trimmed.match(/^([^:#]+):\s*(.*)$/)
+      if (match === null) {
+        throw new Error('Invalid options format')
+      }
+
+      const [, key, value] = match
+      options[key.trim()] = value.trim().replace(/^["']|["']$/g, '')
+    }
+
+    return options
+  }
+}
+
 void (async function main(): Promise<void> {
   try {
     await ssh()
@@ -146,13 +174,12 @@ async function dep(): Promise<void> {
   const options: string[] = []
   try {
     const optionsArg = core.getInput('options')
-    if (optionsArg !== '') {
-      for (const [key, value] of Object.entries(JSON.parse(optionsArg))) {
-        options.push('-o', `${key}=${value}`)
-      }
+    for (const [key, value] of Object.entries(parseOptions(optionsArg))) {
+      options.push('-o', `${key}=${value}`)
     }
   } catch (e) {
-    console.error('Invalid JSON in options')
+    core.setFailed('Invalid options format. Use JSON or key: value lines.')
+    return
   }
 
   let phpBin = 'php'


### PR DESCRIPTION
Fixes #72

## Summary
- Allows `options` to be provided in the key/value line format shown in workflow YAML examples, e.g. `keep_releases: 7`.
- Keeps JSON object support for existing users.
- Fails the action with a clear message when the options input is neither JSON nor key/value lines, instead of silently ignoring invalid JSON.
- Rebuilds `dist/index.js`.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`