### PR TITLE
Surface full action error details

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36632,12 +36632,16 @@ var { VERSION, YAML, argv, dotenv, echo, expBackoff, fetch, fs, glob, globby, mi
 //#endregion
 //#region src/index.ts
 $.verbose = true;
+function formatError(err) {
+	if (err instanceof Error) return err.stack ?? err.message;
+	return String(err);
+}
 (async function main() {
 	try {
 		await ssh();
 		await dep();
 	} catch (err) {
-		setFailed(err instanceof Error ? err.message : String(err));
+		setFailed(formatError(err));
 	}
 })();
 async function ssh() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,20 @@ interface DeployerManifestEntry {
   url: string
 }
 
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.message
+  }
+
+  return String(err)
+}
+
 void (async function main(): Promise<void> {
   try {
     await ssh()
     await dep()
   } catch (err) {
-    core.setFailed(err instanceof Error ? err.message : String(err))
+    core.setFailed(formatError(err))
   }
 })()
 


### PR DESCRIPTION
Fixes #19

## Summary
- Surfaces the full stack trace for JavaScript action errors when available, instead of reducing them to only the error message.
- Keeps the existing string fallback for non-Error throws.
- Rebuilds `dist/index.js` so the action runtime includes the change.

This should make action-level failures like `Callback must be a function. Received undefined` easier to diagnose directly from the workflow log.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- `git diff --check`