### PR TITLE
Add SSH key passphrase input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@
     # Optional.
     private-key: ${{ secrets.PRIVATE_KEY }}
 
+    # Passphrase for the private key, if it is encrypted.
+    # Optional.
+    private-key-passphrase: ${{ secrets.PRIVATE_KEY_PASSPHRASE }}
+
     # Content of `~/.ssh/known_hosts` file. The public SSH keys for a
     # host may be obtained using the utility `ssh-keyscan`.
     # For example: `ssh-keyscan deployer.org`.

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,11 @@ inputs:
     default: ''
     description: The private key for connecting to remote hosts.
 
+  private-key-passphrase:
+    required: false
+    default: ''
+    description: Passphrase for the private key.
+
   known-hosts:
     required: false
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -36650,10 +36650,36 @@ async function ssh() {
 	let privateKey = getInput("private-key");
 	if (privateKey !== "") {
 		privateKey = privateKey.replace(/\r/g, "").trim() + "\n";
+		const privateKeyPassphrase = getInput("private-key-passphrase");
+		const askPassPath = privateKeyPassphrase !== "" ? `${sshHomeDir}/askpass.sh` : "";
+		if (askPassPath !== "") {
+			fs.writeFileSync(askPassPath, "#!/bin/sh\nprintf \"%s\\n\" \"$SSH_KEY_PASSPHRASE\"\n");
+			fs.chmodSync(askPassPath, "700");
+		}
+		const previousAskPass = process.env["SSH_ASKPASS"];
+		const previousAskPassRequire = process.env["SSH_ASKPASS_REQUIRE"];
+		const previousDisplay = process.env["DISPLAY"];
+		const previousKeyPassphrase = process.env["SSH_KEY_PASSPHRASE"];
+		if (askPassPath !== "") {
+			process.env["SSH_ASKPASS"] = askPassPath;
+			process.env["SSH_ASKPASS_REQUIRE"] = "force";
+			process.env["DISPLAY"] = process.env["DISPLAY"] || ":0";
+			process.env["SSH_KEY_PASSPHRASE"] = privateKeyPassphrase;
+		}
 		const p = $`ssh-add -`;
 		p.stdin.write(privateKey);
 		p.stdin.end();
-		await p;
+		try {
+			await p;
+		} finally {
+			if (askPassPath !== "") {
+				restoreEnv("SSH_ASKPASS", previousAskPass);
+				restoreEnv("SSH_ASKPASS_REQUIRE", previousAskPassRequire);
+				restoreEnv("DISPLAY", previousDisplay);
+				restoreEnv("SSH_KEY_PASSPHRASE", previousKeyPassphrase);
+				fs.rmSync(askPassPath, { force: true });
+			}
+		}
 	}
 	const knownHosts = getInput("known-hosts");
 	if (knownHosts !== "") {
@@ -36668,6 +36694,10 @@ async function ssh() {
 		fs.writeFileSync(`${sshHomeDir}/config`, sshConfig);
 		fs.chmodSync(`${sshHomeDir}/config`, "600");
 	}
+}
+function restoreEnv(key, value) {
+	if (value === void 0) delete process.env[key];
+	else process.env[key] = value;
 }
 async function dep() {
 	let bin = getInput("deployer-binary");

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,44 @@ async function ssh(): Promise<void> {
   let privateKey = core.getInput('private-key')
   if (privateKey !== '') {
     privateKey = privateKey.replace(/\r/g, '').trim() + '\n'
+    const privateKeyPassphrase = core.getInput('private-key-passphrase')
+    const askPassPath =
+      privateKeyPassphrase !== '' ? `${sshHomeDir}/askpass.sh` : ''
+
+    if (askPassPath !== '') {
+      fs.writeFileSync(
+        askPassPath,
+        '#!/bin/sh\nprintf "%s\\n" "$SSH_KEY_PASSPHRASE"\n',
+      )
+      fs.chmodSync(askPassPath, '700')
+    }
+
+    const previousAskPass = process.env['SSH_ASKPASS']
+    const previousAskPassRequire = process.env['SSH_ASKPASS_REQUIRE']
+    const previousDisplay = process.env['DISPLAY']
+    const previousKeyPassphrase = process.env['SSH_KEY_PASSPHRASE']
+
+    if (askPassPath !== '') {
+      process.env['SSH_ASKPASS'] = askPassPath
+      process.env['SSH_ASKPASS_REQUIRE'] = 'force'
+      process.env['DISPLAY'] = process.env['DISPLAY'] || ':0'
+      process.env['SSH_KEY_PASSPHRASE'] = privateKeyPassphrase
+    }
+
     const p = $`ssh-add -`
     p.stdin.write(privateKey)
     p.stdin.end()
-    await p
+    try {
+      await p
+    } finally {
+      if (askPassPath !== '') {
+        restoreEnv('SSH_ASKPASS', previousAskPass)
+        restoreEnv('SSH_ASKPASS_REQUIRE', previousAskPassRequire)
+        restoreEnv('DISPLAY', previousDisplay)
+        restoreEnv('SSH_KEY_PASSPHRASE', previousKeyPassphrase)
+        fs.rmSync(askPassPath, { force: true })
+      }
+    }
   }
 
   const knownHosts = core.getInput('known-hosts')
@@ -59,6 +93,14 @@ async function ssh(): Promise<void> {
   if (sshConfig !== '') {
     fs.writeFileSync(`${sshHomeDir}/config`, sshConfig)
     fs.chmodSync(`${sshHomeDir}/config`, '600')
+  }
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
   }
 }
 


### PR DESCRIPTION
Closes #28.\n\n## Summary\n- add a `private-key-passphrase` input for encrypted SSH private keys\n- use a temporary SSH_ASKPASS helper while running `ssh-add -`\n- document the new input and rebuild `dist/index.js`\n\n## Verification\n- `rtk npm run typecheck`\n- `rtk npm run format:check`\n- `rtk npm run build`\n- encrypted SSH key smoke test with `INPUT_PRIVATE-KEY-PASSPHRASE` and `ssh-add -`\n- plain SSH key smoke test without a passphrase